### PR TITLE
Update dependency onoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Reals <support@realsweb.com>",
   "license": "ISC",
   "dependencies": {
-    "onoff": "^4.1.3"
+    "onoff": "^6.0.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Pins won't export properly without the newer onoff package, it also won't accept numbers as pin-numbering.